### PR TITLE
Implement onboarding with free trial paywall

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,15 +1,41 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
 import AddBookmarkScreen from '../screens/AddBookmarkScreen';
+import OnboardingScreen from '../screens/OnboardingScreen';
+import PaywallScreen from '../screens/PaywallScreen';
+import { isOnboardingCompleted, isSubscribed, isTrialActive } from '../subscription/state';
 
 const Stack = createNativeStackNavigator();
 
 const AppNavigator = () => {
+  const [initialRoute, setInitialRoute] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const completed = await isOnboardingCompleted();
+      if (!completed) {
+        setInitialRoute('Onboarding');
+        return;
+      }
+      const subscribed = await isSubscribed();
+      const trial = await isTrialActive();
+      if (subscribed || trial) {
+        setInitialRoute('Home');
+      } else {
+        setInitialRoute('Paywall');
+      }
+    })();
+  }, []);
+
+  if (!initialRoute) return null;
+
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
+      <Stack.Navigator initialRouteName={initialRoute}>
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} options={{ headerShown: false }} />
+        <Stack.Screen name="Paywall" component={PaywallScreen} options={{ title: 'Upgrade' }} />
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="AddBookmark" component={AddBookmarkScreen} />
       </Stack.Navigator>

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { markOnboardingCompleted, startTrial, TRIAL_DAYS } from '../subscription/state';
+
+type RootStackParamList = {
+  Onboarding: undefined;
+  Paywall: undefined;
+  Home: undefined;
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+
+const OnboardingScreen: React.FC<Props> = ({ navigation }) => {
+  const handleContinue = useCallback(async () => {
+    await markOnboardingCompleted();
+    await startTrial();
+    navigation.replace('Home');
+  }, [navigation]);
+
+  const handleSeePlans = useCallback(() => {
+    navigation.navigate('Paywall');
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to Markd</Text>
+      <Text style={styles.subtitle}>Save bookmarks you actually revisit.</Text>
+      <View style={styles.featureList}>
+        <Text style={styles.featureItem}>• Share to add links instantly</Text>
+        <Text style={styles.featureItem}>• Daily reminder surfaces a random link</Text>
+        <Text style={styles.featureItem}>• Lightweight, private, on-device</Text>
+      </View>
+      <TouchableOpacity style={styles.primaryBtn} onPress={handleContinue}>
+        <Text style={styles.primaryBtnText}>Start {TRIAL_DAYS}-day free trial</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.secondaryBtn} onPress={handleSeePlans}>
+        <Text style={styles.secondaryBtnText}>See plans</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 80,
+    paddingHorizontal: 24,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    marginBottom: 8,
+    color: '#111',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#444',
+    marginBottom: 24,
+  },
+  featureList: {
+    marginBottom: 40,
+  },
+  featureItem: {
+    fontSize: 16,
+    color: '#222',
+    marginBottom: 8,
+  },
+  primaryBtn: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryBtnText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  secondaryBtn: {
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  secondaryBtnText: {
+    color: '#007AFF',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});
+
+export default OnboardingScreen;
+

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { activateSubscription, getTrialRemainingDays, isSubscribed, startTrial, TRIAL_DAYS } from '../subscription/state';
+
+type RootStackParamList = {
+  Paywall: undefined;
+  Home: undefined;
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Paywall'>;
+
+const PaywallScreen: React.FC<Props> = ({ navigation }) => {
+  const [trialDaysLeft, setTrialDaysLeft] = useState<number>(0);
+  const [hasSubscription, setHasSubscription] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      setTrialDaysLeft(await getTrialRemainingDays());
+      setHasSubscription(await isSubscribed());
+    })();
+  }, []);
+
+  const handleStartTrial = useCallback(async () => {
+    await startTrial();
+    setTrialDaysLeft(await getTrialRemainingDays());
+    navigation.replace('Home');
+  }, [navigation]);
+
+  const handleSubscribe = useCallback(async () => {
+    // Placeholder: integrate storekit/billing here
+    await activateSubscription();
+    Alert.alert('Success', 'Subscription activated. Thank you!');
+    navigation.replace('Home');
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Go Pro</Text>
+      <Text style={styles.subtitle}>Support development and unlock future features.</Text>
+      <View style={styles.card}>
+        <Text style={styles.price}>$9.99 / year</Text>
+        <Text style={styles.note}>Cancel anytime</Text>
+      </View>
+
+      {trialDaysLeft > 0 ? (
+        <Text style={styles.trialText}>Trial: {trialDaysLeft} day(s) left</Text>
+      ) : (
+        <Text style={styles.trialText}>Start your {TRIAL_DAYS}-day free trial</Text>
+      )}
+
+      {trialDaysLeft <= 0 && (
+        <TouchableOpacity style={styles.primaryBtn} onPress={handleStartTrial}>
+          <Text style={styles.primaryBtnText}>Start Free Trial</Text>
+        </TouchableOpacity>
+      )}
+
+      <TouchableOpacity style={styles.secondaryBtn} onPress={handleSubscribe}>
+        <Text style={styles.secondaryBtnText}>{hasSubscription ? 'Manage Subscription' : 'Subscribe Now'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 80,
+    paddingHorizontal: 24,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    marginBottom: 8,
+    color: '#111',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#444',
+    marginBottom: 24,
+  },
+  card: {
+    backgroundColor: '#f5f7ff',
+    borderRadius: 12,
+    padding: 20,
+    marginBottom: 20,
+  },
+  price: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#0a1c6b',
+  },
+  note: {
+    fontSize: 12,
+    color: '#334',
+    marginTop: 6,
+  },
+  trialText: {
+    textAlign: 'center',
+    color: '#333',
+    marginBottom: 12,
+  },
+  primaryBtn: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryBtnText: {
+    color: '#fff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+  secondaryBtn: {
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  secondaryBtnText: {
+    color: '#007AFF',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+});
+
+export default PaywallScreen;
+

--- a/src/subscription/state.ts
+++ b/src/subscription/state.ts
@@ -1,0 +1,62 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEYS = {
+  onboardingCompleted: 'onboarding.completed',
+  trialStartedAt: 'trial.startedAt',
+  subscriptionActive: 'subscription.active',
+} as const;
+
+const TRIAL_LENGTH_DAYS = 7;
+
+export async function markOnboardingCompleted(): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEYS.onboardingCompleted, 'true');
+}
+
+export async function isOnboardingCompleted(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(STORAGE_KEYS.onboardingCompleted);
+  return value === 'true';
+}
+
+export async function startTrial(): Promise<void> {
+  const now = Date.now().toString();
+  await AsyncStorage.setItem(STORAGE_KEYS.trialStartedAt, now);
+}
+
+export async function getTrialRemainingDays(): Promise<number> {
+  const startedAtStr = await AsyncStorage.getItem(STORAGE_KEYS.trialStartedAt);
+  if (!startedAtStr) return 0;
+  const startedAt = Number(startedAtStr);
+  const msElapsed = Date.now() - startedAt;
+  const daysElapsed = Math.floor(msElapsed / (1000 * 60 * 60 * 24));
+  const remaining = TRIAL_LENGTH_DAYS - daysElapsed;
+  return remaining > 0 ? remaining : 0;
+}
+
+export async function isTrialActive(): Promise<boolean> {
+  const remaining = await getTrialRemainingDays();
+  return remaining > 0;
+}
+
+export async function activateSubscription(): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEYS.subscriptionActive, 'true');
+}
+
+export async function deactivateSubscription(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEYS.subscriptionActive);
+}
+
+export async function isSubscribed(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(STORAGE_KEYS.subscriptionActive);
+  return value === 'true';
+}
+
+export async function resetSubscriptionState(): Promise<void> {
+  await AsyncStorage.multiRemove([
+    STORAGE_KEYS.onboardingCompleted,
+    STORAGE_KEYS.trialStartedAt,
+    STORAGE_KEYS.subscriptionActive,
+  ]);
+}
+
+export const TRIAL_DAYS = TRIAL_LENGTH_DAYS;
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "@react-native/typescript-config"
+  "extends": "@react-native/typescript-config",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["es2017"],
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
Add an onboarding flow with a 7-day free trial and paywall to guide new users and enable subscription monetization.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddd0c098-065f-4888-98aa-0a2dd18f04d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddd0c098-065f-4888-98aa-0a2dd18f04d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

